### PR TITLE
Add:バリデーションを設定

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,4 @@
 class Task < ApplicationRecord
-  validates :content, presence: true
+  validates :name, presence: true
+  validates :content, presence: true, length: { maximum: 100 }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module EducationTask
                    request_specs: false
       g.fixture_replacement :factory_bot, dir: "spec/factories"
     end
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
   end
-  config.time_zone = 'Tokyo'
-  config.active_record.default_timezone = :local
 end

--- a/db/migrate/20190916212751_change_name_column_tasks.rb
+++ b/db/migrate/20190916212751_change_name_column_tasks.rb
@@ -1,0 +1,6 @@
+class ChangeNameColumnTasks < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :tasks, :name, false, 0
+    change_column_null :tasks, :content, false, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_144206) do
+ActiveRecord::Schema.define(version: 2019_09_16_212751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name"
-    t.text "content"
+    t.string "name", null: false
+    t.text "content", null: false
+    t.datetime "create_at"
+    t.datetime "updated_at"
   end
 
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+
+  it "titleが空ならバリデーションが通らない" do
+    task = Task.new(name: '', content: '失敗テスト')
+    expect(task).not_to be_valid
+  end
+
+  it "contentが空ならバリデーションが通らない" do
+    task = Task.new(name: '失敗テスト', content: '')
+    expect(task).not_to be_valid
+  end
+
+  it "titleとcontentに内容が記載されていればバリデーションが通る" do
+    task = Task.new(name: '成功テスト', content: '成功テスト')
+    expect(task).to be_valid
+  end
+end


### PR DESCRIPTION
work5

タスクモデルに対してバリデーションを設定
・nameカラムにnull制約を追記
・contentカラムにnull制約を追記

バリデーションエラーが表示されるように変更
バリデーションエラーが適応されるかどうかテストを追加