### PR TITLE
Add:herokuにデプロイ

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+BASIC_AUTH_NAME = admin
+BASIC_AUTH_PASSWORD = password
+COMPANY= diveintocode

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'factory_bot_rails'
   gem 'spring-commands-rspec'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,10 @@ GEM
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    dotenv (2.7.4)
+    dotenv-rails (2.7.4)
+      dotenv (= 2.7.4)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
@@ -246,6 +250,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   database_cleaner
+  dotenv-rails
   factory_bot_rails
   faker
   jbuilder (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -15,3 +15,23 @@
     - id  integer
     - task_id integer
     - classification text
+
+#   task
+  タスクを登録し、管理するアプリ
+
+# Versioning
+*  ruby 2.6.3
+*  Rails 5.2.3
+*  psql (PostgreSQL) 11.3
+
+#  Deployment
+#  ディレクトリ配下のファイルをコミット対象にする
+  1. git add -A
+#  コミットする
+  2. git commit -m "hogehoge"
+#  リモートリポジトリherokuが作成されていることの確認
+  3.  git remote
+#  ローカルのmasterブランチをリモートリポジトリherokuへpushする
+  4. git push heroku master
+#  マイグレーションは手動で実行する必要があるため、変更した場合は以下のコマンドを入力する
+  5.  heroku run rails:migrate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :basic
+
+  private
+  def basic
+    authenticate_or_request_with_http_basic do |name, password|
+      name == ENV['BASIC_AUTH_NAME'] && password == ENV['BASIC_AUTH_PASSWORD']
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_212751) do
+ActiveRecord::Schema.define(version: 2019_09_18_211720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -3,9 +3,11 @@ RSpec.feature "タスク管理機能", type: :feature do
   background do
     FactoryBot.create(:task, content: 'testtesttest' ,created_at: Time.current + 1.days)
     FactoryBot.create(:second_task, content: 'samplesample', created_at: Time.current + 2.days)
+    page.driver.browser.authorize('admin','password')
   end
   scenario "タスク一覧のテスト" do
   visit tasks_path
+  save_and_open_page
   expect(page).to have_content 'testtesttest'
   expect(page).to have_content 'samplesample'
 
@@ -28,8 +30,9 @@ RSpec.feature "タスク管理機能", type: :feature do
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
     visit tasks_path
     click_on '作成日時順にする'
-    expect(page).to have_content 'samplesample'
-    expect(page).to have_content 'testtesttest'
-    save_and_open_page
+    tds = page.all('td')
+    binding.pry
+    expect(tds[1]).to have_content 'samplesample'
+    expect(tds[7]).to have_content 'testtesttest'
   end
 end


### PR DESCRIPTION
# work6

1.作成しているtaskアプリをWebサーバー(heroku)にデプロイする
2.herokuにBASIC認証を実装
3.README.mdにherokuへのデプロイ手順を記載
4.herokuとgithubを連携させて自動デプロイ環境を実装

参考資料
https://j-hack.gitbooks.io/deploy-meteor-app-to-heroku/content/step4.html
ステップ4